### PR TITLE
test: custom components architecture

### DIFF
--- a/tests/Arch/Components/CustomComponentsArchTest.php
+++ b/tests/Arch/Components/CustomComponentsArchTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Webid\Druid\Components\ComponentInterface;
+
+test('should implements ComponentInterface')
+    ->expect('app\Filament\Components')
+    ->toBeClasses()
+    ->toImplement(ComponentInterface::class);

--- a/tests/Arch/Components/CustomComponentsArchTest.php
+++ b/tests/Arch/Components/CustomComponentsArchTest.php
@@ -14,7 +14,7 @@ it('should implement the interface methods')
     ->expect('app\Filament\Components')
     ->toHaveMethods(['blockSchema', 'fieldName', 'toBlade', 'toSearchableContent', 'imagePreview']);
 
-test('component should be registered at config/cms', function () {
+test('component should be registered at config/cms', function (): void {
     $componentsConfig = Config::get('cms.components');
     expect($componentsConfig)
         ->toBeArray()
@@ -27,12 +27,12 @@ test('component should be registered at config/cms', function () {
 
         expect(class_exists($componentClass))
             ->and($componentClass)
-            ->toStartWith('App\Filament\Components' . '\\')
+            ->toStartWith('App\Filament\Components\\')
             ->toHaveSuffix('Component');
     }
 });
 
-test('component should be registered at TemplateRendererClass', function () {
+test('component should be registered at TemplateRendererqqClass', function (): void {
     $templateRenderer = app(TemplateRenderer::class);
     $templateRenderer->render('Component That is not Registered');
 })->throws(ViewException::class);

--- a/tests/Arch/Components/CustomComponentsArchTest.php
+++ b/tests/Arch/Components/CustomComponentsArchTest.php
@@ -6,3 +6,7 @@ test('should implements ComponentInterface')
     ->expect('app\Filament\Components')
     ->toBeClasses()
     ->toImplement(ComponentInterface::class);
+
+it('should implement the interface methods')
+    ->expect('app\Filament\Components')
+    ->toHaveMethods(['blockSchema', 'fieldName', 'toBlade', 'toSearchableContent', 'imagePreview']);

--- a/tests/Arch/Components/CustomComponentsArchTest.php
+++ b/tests/Arch/Components/CustomComponentsArchTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\View\TemplateRenderer;
 use Illuminate\Support\Facades\Config;
+use Illuminate\View\ViewException;
 use Webid\Druid\Components\ComponentInterface;
 
 test('should implements ComponentInterface')
@@ -29,3 +31,8 @@ test('component should be registered at config/cms', function () {
             ->toHaveSuffix('Component');
     }
 });
+
+test('component should be registered at TemplateRendererClass', function () {
+    $templateRenderer = app(TemplateRenderer::class);
+    $templateRenderer->render('Component That is not Registered');
+})->throws(ViewException::class);

--- a/tests/Arch/Components/CustomComponentsArchTest.php
+++ b/tests/Arch/Components/CustomComponentsArchTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Config;
 use Webid\Druid\Components\ComponentInterface;
 
 test('should implements ComponentInterface')
@@ -10,3 +11,21 @@ test('should implements ComponentInterface')
 it('should implement the interface methods')
     ->expect('app\Filament\Components')
     ->toHaveMethods(['blockSchema', 'fieldName', 'toBlade', 'toSearchableContent', 'imagePreview']);
+
+test('component should be registered at config/cms', function () {
+    $componentsConfig = Config::get('cms.components');
+    expect($componentsConfig)
+        ->toBeArray()
+        ->and($componentsConfig)->not->toBeEmpty('The "cms.components" configuration array is empty.');
+
+    foreach ($componentsConfig as $component) {
+        expect($component)->toHaveKey('class', $component['class']);
+
+        $componentClass = $component['class'];
+
+        expect(class_exists($componentClass))
+            ->and($componentClass)
+            ->toStartWith('App\Filament\Components' . '\\')
+            ->toHaveSuffix('Component');
+    }
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,7 +16,7 @@ use Tests\TestCase;
 
 pest()->extend(TestCase::class)
     ->use(RefreshDatabase::class)
-    ->in('Feature');
+    ->in('Feature', 'Arch');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds a suite of tests to ensure the custom components are implemented according to the guidelines specified in the "Adding Custom Components to the CMS" documentation.

## Changes Made:

- **Component Interface Implementation**:  
  The tests confirm that the component in question properly implements the `ComponentInterface` as required by the CMS structure.  
  - The `should implement ComponentInterface` test ensures that the component class implements the interface correctly.

- **Required Methods**:  
  The tests verify that the necessary methods (`blockSchema`, `fieldName`, `toBlade`, `toSearchableContent`, `imagePreview`) are present in the component class.  
  - The `should implement the interface methods` test checks that the component has all required methods.

- **Configuration Registration**:  
  The component is verified to be correctly registered within the CMS configuration (`config/cms.php`).  
  - The `component should be registered at config/cms` test ensures that the component is listed with its fully qualified class name and follows the naming conventions (`App\Filament\Components\\` suffixing with `Component`).

- **TemplateRenderer Registration**:  
  The tests check that the component is registered correctly in the `TemplateRenderer` class and throws an exception if the component isn't registered.  
  - The `component should be registered at TemplateRendererClass` test ensures that an error is thrown if the component is not found when rendering.
