### PR TITLE
feat/added google font (syne)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Syne:wght@400..800&display=swap');
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
+
+@theme {
+    --font-syne: "Syne", sans-serif;
+}
 
 @theme inline {
     --color-base-100: var(--base-100);

--- a/resources/views/components/landing/our-work.blade.php
+++ b/resources/views/components/landing/our-work.blade.php
@@ -35,7 +35,7 @@
                 <span class="text-sm text-primary font-semibold">{{ $subheading }}</span>
             </div>
             <!-- Main Heading -->
-            <h2 class="text-base-content text-4xl sm:text-5xl font-extrabold leading-tight mb-6 tracking-tight">
+            <h2 class="text-base-content font-bold text-4xl sm:text-5xl  leading-tight mb-6 tracking-tight">
                 {{ $heading }}
             </h2>
             <!-- Descriptive Paragraph -->

--- a/resources/views/components/layout/guest.blade.php
+++ b/resources/views/components/layout/guest.blade.php
@@ -60,7 +60,7 @@
 
 
 </head>
-<body class="bg-base-100">
+<body class="bg-base-100 font-syne">
 <noscript>
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KTVLGCHG" class="hidden h-0 w-0"></iframe>
 </noscript>


### PR DESCRIPTION
At `app.css` we have a new import for the Google Font "Syne", as well as it's implementation. It was defined as the project's main font at `guest.blade.php` .

Closes #38 