### PR TITLE
feat: shared headline

### DIFF
--- a/app/Filament/Components/DTOs/BadgeComponent.php
+++ b/app/Filament/Components/DTOs/BadgeComponent.php
@@ -11,22 +11,26 @@ class BadgeComponent
     public function __construct(
         public ?string $label,
         public ?string $icon,
-        public bool $hasBadge,
-    ) {}
-
-    public static function form(string $parent = ''): array
+        public bool    $hasBadge,
+    )
     {
+    }
+
+    public static function form(?string $parent): array
+    {
+        $parent = $parent !== null && $parent !== '' && $parent !== '0' ? $parent . '.' : null;
+
         return [
-            Toggle::make($parent . '.badge.has_badge')
+            Toggle::make($parent . 'has_badge')
                 ->label('Has Badge?')
                 ->live(debounce: 50)
                 ->default(false),
-            IconPicker::make($parent . '.badge.icon')
+            IconPicker::make($parent . 'icon')
                 ->label('Icon')
-                ->visible(fn ($get) => $get($parent . '.badge.has_badge'))
+                ->visible(fn($get) => $get($parent . 'has_badge'))
                 ->default('heroicon-o-tag'),
-            TextInput::make($parent . 'badge.label')
-                ->visible(fn ($get) => $get($parent . '.badge.has_badge'))
+            TextInput::make($parent . 'label')
+                ->visible(fn($get) => $get($parent . 'has_badge'))
                 ->label('Badge')
                 ->nullable()
                 ->default('Consultoria Financeira'),
@@ -35,6 +39,13 @@ class BadgeComponent
 
     public static function make(array $data): self
     {
+        if (!isset($data['badge'])) {
+            return new self(
+                label: null,
+                icon: null,
+                hasBadge: false,
+            );
+        }
 
         $badge = $data['badge'];
 

--- a/app/Filament/Components/DTOs/BadgeComponent.php
+++ b/app/Filament/Components/DTOs/BadgeComponent.php
@@ -11,10 +11,8 @@ class BadgeComponent
     public function __construct(
         public ?string $label,
         public ?string $icon,
-        public bool    $hasBadge,
-    )
-    {
-    }
+        public bool $hasBadge,
+    ) {}
 
     public static function form(?string $parent): array
     {
@@ -27,10 +25,10 @@ class BadgeComponent
                 ->default(false),
             IconPicker::make($parent . 'icon')
                 ->label('Icon')
-                ->visible(fn($get) => $get($parent . 'has_badge'))
+                ->visible(fn ($get) => $get($parent . 'has_badge'))
                 ->default('heroicon-o-tag'),
             TextInput::make($parent . 'label')
-                ->visible(fn($get) => $get($parent . 'has_badge'))
+                ->visible(fn ($get) => $get($parent . 'has_badge'))
                 ->label('Badge')
                 ->nullable()
                 ->default('Consultoria Financeira'),
@@ -39,7 +37,7 @@ class BadgeComponent
 
     public static function make(array $data): self
     {
-        if (!isset($data['badge'])) {
+        if (! isset($data['badge'])) {
             return new self(
                 label: null,
                 icon: null,

--- a/app/Filament/Components/DTOs/ButtonComponent.php
+++ b/app/Filament/Components/DTOs/ButtonComponent.php
@@ -57,7 +57,7 @@ class ButtonComponent
 
     public static function makeCollection(array $payload): Collection
     {
-        if(!isset($payload['buttons'])) {
+        if (! isset($payload['buttons'])) {
             return collect();
         }
 

--- a/app/Filament/Components/DTOs/ButtonComponent.php
+++ b/app/Filament/Components/DTOs/ButtonComponent.php
@@ -57,11 +57,17 @@ class ButtonComponent
 
     public static function makeCollection(array $payload): Collection
     {
+        if(!isset($payload['buttons'])) {
+            return collect();
+        }
+
+        $payload = $payload['buttons'];
+
         if (! $payload['has_actions']) {
             return collect();
         }
 
-        return collect($payload['actions'] ?? [])
-            ->map(fn ($button): \App\Filament\Components\DTOs\ButtonComponent => self::make($button));
+        return collect($payload['buttons'] ?? [])
+            ->map(fn ($button): ButtonComponent => self::make($button));
     }
 }

--- a/app/Filament/Components/DTOs/HeadlineComponent.php
+++ b/app/Filament/Components/DTOs/HeadlineComponent.php
@@ -2,7 +2,9 @@
 
 namespace App\Filament\Components\DTOs;
 
+use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
 use Illuminate\Support\Collection;
 
@@ -11,24 +13,45 @@ use function Illuminate\Log\log;
 class HeadlineComponent
 {
     /**
-     * @param  Collection<int, ButtonComponent>  $actions
+     * @param Collection<int, ButtonComponent> $actions
      */
     public function __construct(
         public ?BadgeComponent $badge,
-        public string $heading,
-        public string $description,
-        public string $position,
-        public Collection $actions,
-    ) {}
+        public string          $heading,
+        public array           $keywords,
+        public ?string          $description,
+        public string          $position,
+        public string          $size,
+        public Collection      $actions,
+    )
+    {
+    }
 
     public static function form(): array
     {
         return [
+            Fieldset::make('Headline')
+                ->columns(1)
+            ->schema([
             TextInput::make('headline.heading')
                 ->label('Heading')
+                ->reactive()
+                ->afterStateUpdated(fn($state, $set) => $set('headline.keywords', str($state)->explode(' ')))
                 ->required()
                 ->default('Invista no futuro com inteligência e precisão'),
-
+            TagsInput::make('headline.keywords')
+                ->label('Keywords'),
+            Select::make('headline.size')
+                ->label('Size')
+                ->options([
+                    'sm' => 'Small',
+                    'md' => 'Medium',
+                    'lg' => 'Large',
+                    'xl' => 'Extra Large',
+                    '2xl' => '2x Extra Large',
+                    '3xl' => '3x Extra Large',
+                    '4xl' => '4x Extra Large',
+                ]),
             Select::make('headline.position')
                 ->label('Position')
                 ->options([
@@ -40,22 +63,21 @@ class HeadlineComponent
 
             TextInput::make('headline.description')
                 ->label('Subheading')
-                ->required()
                 ->default('Transformamos a forma como as pessoas lidam com dinheiro, capacitando-as a conquistar liberdade, segurança e crescimento financeiro sustentável.'),
-            ...BadgeComponent::form('headline'),
-            ...ButtonComponent::form('headline'),
-        ];
+            ...BadgeComponent::form('headline.badge'),
+            ...ButtonComponent::form('headline.buttons'),
+            ])];
     }
 
     public static function make(array $data): self
     {
-        log($data);
-
         return new self(
             badge: BadgeComponent::make($data),
             heading: $data['heading'],
+            keywords: $data['keywords'] ?? [],
             description: $data['description'],
             position: $data['position'] ?? 'left',
+            size: $data['size'] ?? 'md',
             actions: ButtonComponent::makeCollection($data),
         );
     }

--- a/app/Filament/Components/DTOs/HeadlineComponent.php
+++ b/app/Filament/Components/DTOs/HeadlineComponent.php
@@ -8,65 +8,61 @@ use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
 use Illuminate\Support\Collection;
 
-use function Illuminate\Log\log;
-
 class HeadlineComponent
 {
     /**
-     * @param Collection<int, ButtonComponent> $actions
+     * @param  Collection<int, ButtonComponent>  $actions
      */
     public function __construct(
         public ?BadgeComponent $badge,
-        public string          $heading,
-        public array           $keywords,
-        public ?string          $description,
-        public string          $position,
-        public string          $size,
-        public Collection      $actions,
-    )
-    {
-    }
+        public string $heading,
+        public array $keywords,
+        public ?string $description,
+        public string $position,
+        public string $size,
+        public Collection $actions,
+    ) {}
 
     public static function form(): array
     {
         return [
             Fieldset::make('Headline')
                 ->columns(1)
-            ->schema([
-            TextInput::make('headline.heading')
-                ->label('Heading')
-                ->reactive()
-                ->afterStateUpdated(fn($state, $set) => $set('headline.keywords', str($state)->explode(' ')))
-                ->required()
-                ->default('Invista no futuro com inteligência e precisão'),
-            TagsInput::make('headline.keywords')
-                ->label('Keywords'),
-            Select::make('headline.size')
-                ->label('Size')
-                ->options([
-                    'sm' => 'Small',
-                    'md' => 'Medium',
-                    'lg' => 'Large',
-                    'xl' => 'Extra Large',
-                    '2xl' => '2x Extra Large',
-                    '3xl' => '3x Extra Large',
-                    '4xl' => '4x Extra Large',
-                ]),
-            Select::make('headline.position')
-                ->label('Position')
-                ->options([
-                    'left' => 'Left',
-                    'center' => 'Center',
-                    'right' => 'Right',
-                ])
-                ->default('left'),
+                ->schema([
+                    TextInput::make('headline.heading')
+                        ->label('Heading')
+                        ->reactive()
+                        ->afterStateUpdated(fn ($state, $set) => $set('headline.keywords', str($state)->explode(' ')))
+                        ->required()
+                        ->default('Invista no futuro com inteligência e precisão'),
+                    TagsInput::make('headline.keywords')
+                        ->label('Keywords'),
+                    Select::make('headline.size')
+                        ->label('Size')
+                        ->options([
+                            'sm' => 'Small',
+                            'md' => 'Medium',
+                            'lg' => 'Large',
+                            'xl' => 'Extra Large',
+                            '2xl' => '2x Extra Large',
+                            '3xl' => '3x Extra Large',
+                            '4xl' => '4x Extra Large',
+                        ]),
+                    Select::make('headline.position')
+                        ->label('Position')
+                        ->options([
+                            'left' => 'Left',
+                            'center' => 'Center',
+                            'right' => 'Right',
+                        ])
+                        ->default('left'),
 
-            TextInput::make('headline.description')
-                ->label('Subheading')
-                ->default('Transformamos a forma como as pessoas lidam com dinheiro, capacitando-as a conquistar liberdade, segurança e crescimento financeiro sustentável.'),
-            ...BadgeComponent::form('headline.badge'),
-            ...ButtonComponent::form('headline.buttons'),
-            ])];
+                    TextInput::make('headline.description')
+                        ->label('Subheading')
+                        ->default('Transformamos a forma como as pessoas lidam com dinheiro, capacitando-as a conquistar liberdade, segurança e crescimento financeiro sustentável.'),
+                    ...BadgeComponent::form('headline.badge'),
+                    ...ButtonComponent::form('headline.buttons'),
+                ])];
     }
 
     public static function make(array $data): self

--- a/app/Filament/Components/Partials/CtaFullWidthComponent.php
+++ b/app/Filament/Components/Partials/CtaFullWidthComponent.php
@@ -4,6 +4,7 @@ namespace App\Filament\Components\Partials;
 
 use App\Enums\CustomComponent;
 use App\Filament\Components\AbstractCustomComponent;
+use App\Filament\Components\DTOs\HeadlineComponent;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\TextInput;
@@ -19,9 +20,6 @@ class CtaFullWidthComponent extends AbstractCustomComponent
         return [
             Hidden::make('component_id')
                 ->formatStateUsing(fn ($state) => $state ?? Uuid::uuid4()->toString()),
-            TextInput::make('title')
-                ->required()
-                ->label(__('Title')),
             SpatieMediaLibraryFileUpload::make('hero')
                 ->label('Hero Image')
                 ->customProperties(fn (Get $get): array => [
@@ -36,6 +34,9 @@ class CtaFullWidthComponent extends AbstractCustomComponent
                 ->collection(CustomComponent::CallToActionFullWidthSection->value)
                 ->image()
                 ->required(),
+
+            ...HeadlineComponent::form(),
+
             TextInput::make('cta_label')
                 ->required()
                 ->label(__('Call to Action Label')),
@@ -54,7 +55,7 @@ class CtaFullWidthComponent extends AbstractCustomComponent
     public static function setupRenderPayload(array $data): array
     {
         return [
-            'title' => $data['title'],
+            'headline' => HeadlineComponent::make($data['headline']),
             'cta_label' => $data['cta_label'],
             'cta_url' => $data['cta_url'],
             'component_id' => $data['component_id'],

--- a/app/Filament/Components/Partials/InfoStatsComponent.php
+++ b/app/Filament/Components/Partials/InfoStatsComponent.php
@@ -20,6 +20,7 @@ class InfoStatsComponent extends AbstractCustomComponent
             ...HeadlineComponent::form(),
             Repeater::make('metrics')
                 ->label('Metrics')
+                ->collapsible()
                 ->schema([
                     TextInput::make('label')
                         ->label('Label')
@@ -48,7 +49,6 @@ class InfoStatsComponent extends AbstractCustomComponent
 
     public static function setupRenderPayload(array $data): array
     {
-
         return [
             'headline' => HeadlineComponent::make($data['headline']),
             'metrics' => collect($data['metrics'] ?? [])->map(fn ($metric) => Fluent::make([

--- a/app/Filament/Components/Partials/PlansComponent.php
+++ b/app/Filament/Components/Partials/PlansComponent.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Components\Partials;
 
 use App\Filament\Components\AbstractCustomComponent;
+use App\Filament\Components\DTOs\HeadlineComponent;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -15,12 +16,7 @@ class PlansComponent extends AbstractCustomComponent
     public static function blockSchema(): array
     {
         return [
-            TextInput::make('heading')
-                ->label(__('Heading'))
-                ->required(),
-            TextInput::make('subheading')
-                ->label(__('Subheading'))
-                ->required(),
+            ...HeadlineComponent::form(),
             Repeater::make('plans')
                 ->label(__('Plans'))
                 ->cloneable()
@@ -70,8 +66,7 @@ class PlansComponent extends AbstractCustomComponent
     public static function setupRenderPayload(array $data): array
     {
         return [
-            'heading' => $data['heading'],
-            'subheading' => $data['subheading'],
+            'headline' => HeadlineComponent::make($data['headline']),
             'plans' => collect($data['plans'] ?? [])->map(fn ($plan) => Fluent::make([
                 'best_plan' => $plan['best_plan'] ?? false,
                 'name' => $plan['name'],

--- a/app/Filament/Components/Partials/RoadmapComponent.php
+++ b/app/Filament/Components/Partials/RoadmapComponent.php
@@ -4,7 +4,6 @@ namespace App\Filament\Components\Partials;
 
 use App\Filament\Components\AbstractCustomComponent;
 use App\Filament\Components\DTOs\HeadlineComponent;
-use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;

--- a/app/Filament/Components/Partials/RoadmapComponent.php
+++ b/app/Filament/Components/Partials/RoadmapComponent.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Components\Partials;
 
 use App\Filament\Components\AbstractCustomComponent;
+use App\Filament\Components\DTOs\HeadlineComponent;
 use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
@@ -16,21 +17,7 @@ class RoadmapComponent extends AbstractCustomComponent
     public static function blockSchema(): array
     {
         return [
-            'heading' => TextInput::make('heading')
-                ->required()
-                ->label(__('Title'))
-                ->default('Our Roadmap'),
-
-            'subheading' => MarkdownEditor::make('subheading')
-                ->required()
-                ->label(__('Description'))
-                ->default('A brief overview of our roadmap and future plans.'),
-
-            'caption' => MarkdownEditor::make('caption')
-                ->required()
-                ->label(__('Description'))
-                ->default('A brief overview of our roadmap and future plans.'),
-
+            ...HeadlineComponent::form(),
             'steps' => Repeater::make('steps')
                 ->label(__('Steps'))
                 ->schema([
@@ -84,12 +71,10 @@ class RoadmapComponent extends AbstractCustomComponent
     public static function setupRenderPayload(array $data): array
     {
         return [
-            'heading' => $data['heading'] ?? '',
-            'subheading' => $data['subheading'] ?? '',
+            'headline' => HeadlineComponent::make($data['headline']),
             'cta_label' => $data['cta_label'] ?? '',
             'cta_url' => $data['cta_url'] ?? '',
             'steps' => $data['steps'] ?? [],
-            'caption' => $data['caption'] ?? [],
         ];
     }
 

--- a/resources/views/components/headline.blade.php
+++ b/resources/views/components/headline.blade.php
@@ -2,7 +2,7 @@
     use App\Filament\Components\DTOs\HeadlineComponent;
 @endphp
 @props([
-    'as' => 'section',
+    'as' => 'div',
     // layout & behavior
     'align' => 'center',     // center|left
     'size'  => 'xl',         // sm|md|lg|xl
@@ -27,14 +27,17 @@
             : null;
 
         $align = $component->position;
+        $size = $component->size;
     }
 
 
     $tag = $as;
 
-    $alignCls = $align === 'left'
-        ? 'lg:text-left text-left flex flex-col items-start'
-        : 'text-center lg:text-left flex flex-col items-center';
+    $alignCls = match($align) {
+        'left' => 'lg:text-left text-left flex flex-col items-start',
+        'center' => 'text-center lg:text-center flex flex-col items-center',
+        default => 'text-center lg:text-left flex flex-col items-center',
+    };
 
     $animateCls = $animate ? 'animate-fade-in' : '';
 
@@ -46,37 +49,70 @@
         ],
         'md' => [
             'h' => 'text-xl sm:text-2xl md:text-3xl lg:text-4xl',
-                 'p' => 'text-sm sm:text-base md:text-lg'],
-        'lg' => ['h' => 'text-2xl sm:text-3xl md:text-4xl lg:text-5xl',
-                 'p' => 'text-base md:text-lg lg:text-xl'],
-        'xl' => ['h' => 'text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl',
-                 'p' => 'text-sm sm:text-base md:text-lg lg:text-xl'],
+            'p' => 'text-sm sm:text-base md:text-lg'
+        ],
+        'lg' => [
+            'h' => 'text-2xl sm:text-3xl md:text-4xl lg:text-5xl',
+            'p' => 'text-base md:text-lg lg:text-xl'
+        ],
+        'xl' => [
+            'h' => 'text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl',
+            'p' => 'text-sm sm:text-base md:text-lg lg:text-xl'
+        ],
+        '2xl' => [
+            'h' => 'text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl',
+            'p' => 'text-base md:text-lg lg:text-xl xl:text-2xl'
+        ],
+        '3xl' => [
+            'h' => 'text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl',
+            'p' => 'text-lg md:text-xl lg:text-2xl xl:text-3xl'
+        ],
+        '4xl' => [
+            'h' => 'text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl',
+            'p' => 'text-xl md:text-2xl lg:text-3xl xl:text-4xl'
+        ],
+
     ][$size] ?? ['h' => 'text-2xl md:text-3xl', 'p' => 'text-base'];
 
 @endphp
 
 <{{ $tag }} {{ $attributes->merge(['class' => "$animateCls  $alignCls "]) }}>
-{{-- Badge (optional) --}}
+
 @isset($badge)
     <div {{ $badge->attributes }}>
         {{ $badge }}
     </div>
 @endisset
 
-@isset($badgeComponent)
-    <x-badge :component="$badgeComponent" />
+@if(isset($badgeComponent) && $badgeComponent->hasBadge)
+    <x-badge :component="$badgeComponent"/>
 @endif
 
 
-@isset($headline))
+@isset($headline)
+
     <h1 {{ $headline->attributes->class("text-text-high font-bold drop-shadow-lg leading-tight mb-2 sm:mb-4 ") }}>
         {{ $component->headline ?? $headline }}
     </h1>
 @endisset
 
 @if($component->heading)
-    <h1 {{ $attributes->merge(['class' => "text-text-high text-2xl font-bold drop-shadow-lg leading-tight mb-2 sm:mb-4 " . $sizes['h']]) }}>
-        {{ $component->heading }}
+    <h1 {{ $attributes->merge(['class' => "text-text-high text-2xl font-bold drop-shadow-lg tracking-wide mb-2 sm:mb-4 " . $sizes['h']]) }}>
+
+        @php
+            $headline = str($component->heading)->explode(' ');
+        @endphp
+        @foreach($headline as $word)
+            @if(in_array($word, $component->keywords))
+                <span class="text-brand-primary">{{ $word }}</span>
+            @else
+                {{ $word }}
+            @endif
+            @if(!$loop->last)
+                {{-- Add space between words except after the last one --}}
+                {{ ' ' }}
+            @endif
+        @endforeach
     </h1>
 @endisset
 
@@ -84,13 +120,13 @@
 
 
 @isset($description)
-    <p {{ $description->attributes->class("text-text-high dark:text-text-medium font-medium animate-fade-in delay-200 max-w-full mb-4 sm:mb-6 $sizes[p] ".($align==='left'?'text-left':'text-center lg:text-left')) }}>
+    <p {{ $description->attributes->class("text-text-high dark:text-text-medium font-medium animate-fade-in delay-200 max-w-full mb-4 sm:mb-6 " . $sizes['p']) }}>
         {{ $description }}
     </p>
 @endisset
 
 @if($componentDescription)
-    <p {{ $attributes->merge(['class' => "text-text-high dark:text-text-medium font-medium animate-fade-in delay-200 max-w-full mb-4 sm:mb-6 $sizes[p] ".($align==='left'?'text-left':'text-center lg:text-left')]) }}>
+    <p {{ $attributes->merge(['class' => "text-text-high dark:text-text-medium font-medium animate-fade-in delay-200 max-w-full mb-4 sm:mb-6 " . $sizes['p']]) }}>
         {{ $componentDescription }}
     </p>
 @endisset

--- a/resources/views/components/sections/cta-full-width.blade.php
+++ b/resources/views/components/sections/cta-full-width.blade.php
@@ -20,10 +20,8 @@ $variant = $renderable->theme->value;
         <div class="absolute bottom-2 right-2 sm:bottom-4 sm:right-4 md:bottom-6 md:right-6 lg:bottom-8 lg:right-8 rotate-180">
             <x-partials.corner class="w-[40px] h-[40px] sm:w-[60px] sm:h-[60px] md:w-[80px] md:h-[80px] lg:w-[100px] lg:h-[100px]"/>
         </div>
-        <div class="relative z-10 flex flex-col items-center justify-center max-w-6xl mx-auto px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16">
-            <h2 class="text-xl sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl 2xl:text-6xl font-bold text-white text-center leading-tight max-w-4xl">
-                {{ $title }}
-            </h2>
+        <div class="relative z-10 flex flex-col items-center justify-center max-w-[80svw] mx-auto px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16">
+            <x-headline :component="$headline"/>
             <x-layout.shared.button :href="$cta_url" :$variant class="px-4 py-2 sm:px-6 sm:py-2 md:px-7 md:py-2.5 lg:px-8 lg:py-3 text-sm sm:text-base md:text-lg mt-4 sm:mt-6 md:mt-8 lg:mt-10 text-text-dark">
                 {{ $cta_label }}
             </x-layout.shared.button>

--- a/resources/views/components/sections/info-stats.blade.php
+++ b/resources/views/components/sections/info-stats.blade.php
@@ -10,12 +10,11 @@
 
 <section class="container mx-auto mb-32">
     <div class="flex flex-col lg:grid lg:grid-cols-12">
-        <div id="left-info" class="col-span-4">
-            <x-headline :component="$headline" size="md"/>
+        <div class="col-span-4 px-2">
+            <x-headline :component="$headline"/>
         </div>
 
-        <div id="right"
-             class="grid col-span-8 col-start-5 grid-cols-2 lg:grid-cols-2 xl:grid-cols-4 gap-4 md:gap-8">
+        <div class="grid col-span-8 col-start-5 grid-cols-2 lg:grid-cols-2 xl:grid-cols-4 gap-4 md:gap-8">
             @foreach ($metrics as $metric)
                 <x-card variant="stat" class="my-15" interactive>
                     <x-slot:icon>

--- a/resources/views/components/sections/plans.blade.php
+++ b/resources/views/components/sections/plans.blade.php
@@ -1,13 +1,11 @@
 @props([
-    'heading' => 'Planos e preços',
-    'description' =>
-        'Na nossa consultoria, entendemos que cada cliente é único. Por isso, desenvolvemos uma metodologia personalizada que se adapta às suas necessidades e objetivos financeiros. Nossa abordagem é baseada em três pilares fundamentais: Análise de Perfil, Planejamento Estratégico e Execução com Suporte Contínuo.',
+    'headline',
     'plans' => collect(),
 ])
 <section class="py-12 sm:py-16 md:py-20 lg:py-24 bg-elevation-02dp">
     <div class="mx-auto flex flex-col items-center container px-4 sm:px-6 lg:px-8">
         <div class="mb-8 sm:mb-12 md:mb-14 lg:mb-16 w-full max-w-4xl">
-            <x-layout.shared.section-header :heading="$heading" :description="$description"/>
+            <x-headline :component="$headline"/>
         </div>
         <div class="w-full ">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 md:gap-10 lg:gap-12">

--- a/resources/views/components/sections/roadmap.blade.php
+++ b/resources/views/components/sections/roadmap.blade.php
@@ -1,10 +1,8 @@
 @props([
-    'heading',
-    'subheading',
+    'headline',
     'cta_label',
     'cta_url',
     'steps' => [],
-    'caption'
 ])
 @php
     $grid = [
@@ -17,12 +15,7 @@
 <section class="w-full">
     <div class="container mx-auto">
         <div class="flex flex-col items-center justify-center space-y-6 text-center">
-            <div class="space-y-4 max-w-5xl flex flex-col items-center justify-center">
-                <x-layout.shared.section-header
-                    :$heading
-                    :description="$subheading"
-                />
-            </div>
+            <x-headline :component="$headline" />
         </div>
         <div class="hidden lg:block mx-auto py-16 relative">
             <img src="{{ asset('images/dashed-line-1.svg') }}" alt="Process Background"
@@ -31,13 +24,12 @@
                  class="absolute 2xl:top-[615px] 2xl:left-[735px] xl:top-[649px] xl:left-[500px] lg:left-[445px] lg:top-[750px]">
             <div class="grid grid-cols-16 gap-4">
                 @foreach($steps as $index => $card)
-                    <div @class($grid[$index])>
+                    <div>
                         <x-cards.process-card
                             :number="$index + 1"
                             :icon="$card['icon']"
                             :title="$card['title']"
                             :description="$card['description']"
-                            :class="$card['class']"
                             :cta_label="$card['cta_label'] ?? null"
                             :cta_url="$card['cta_url'] ?? null"
                         />
@@ -58,14 +50,6 @@
             </div>
         </div>
 
-        <div class="flex flex-col items-center justify-center space-y-6 text-center">
-            <p class="text-text-medium max-w-3xl mx-auto text-sm sm:text-base">
-                {{ $caption }}
-            </p>
 
-            <x-layout.shared.button :href="$cta_url" class="px-6 sm:px-8 py-3 sm:py-4 font-semibold w-full sm:w-auto">
-                {{ $cta_label }}
-            </x-layout.shared.button>
-        </div>
     </div>
 </section>

--- a/resources/views/components/sections/split-horizontal-three-steps.blade.php
+++ b/resources/views/components/sections/split-horizontal-three-steps.blade.php
@@ -1,9 +1,5 @@
 @props([
-    'subheading',
-    'heading',
-    'description',
-    'cta_label',
-    'cta_url',
+    'headline',
     'cards' => [],
     'grid_columns',
     'card_type'


### PR DESCRIPTION
This pull request refactors headline management across several components, centralizing headline logic into a new `HeadlineComponent` DTO. It replaces previous ad-hoc heading and subheading fields with a unified headline structure, adds support for keywords and sizing, and updates Blade views to leverage these changes for improved consistency and flexibility. Badge and button handling are also streamlined, and several UI components now use the new headline system.

**Headline and DTO Refactoring:**

* Introduced `HeadlineComponent` DTO with support for keywords, size, position, and badges; updated its form schema to use `Fieldset`, `TagsInput`, and a more flexible size selector. Badge and button forms are now integrated via dynamic parent keys. [[1]](diffhunk://#diff-e72266d4ac38927509c29a37e7dde6220e0dd1650c41d44d2ce886da670a5d5bL19-R54) [[2]](diffhunk://#diff-e72266d4ac38927509c29a37e7dde6220e0dd1650c41d44d2ce886da670a5d5bL43-R80)
* Updated partial components (`CtaFullWidthComponent`, `InfoStatsComponent`, `PlansComponent`, `RoadmapComponent`) to use `HeadlineComponent::form()` for headline fields and `HeadlineComponent::make()` for rendering payloads, replacing previous heading/subheading logic. [[1]](diffhunk://#diff-1ab388f925913e6760e9ebd3ea96538225b42827ad6f4d7b8122377be6257e73R37-R39) [[2]](diffhunk://#diff-adf1c4f354d04c1e31d3f1ff6a39e7ca3b43bbe5e49989ef960723edf2a00d36L51) [[3]](diffhunk://#diff-8d59f5ab8ae056ccd4bc9b92e731afb4d0b4fd2265d79a066a232bf4e1aff13eL18-R19) [[4]](diffhunk://#diff-c7c51e83b03c94c1daa235fc30964c8449e4ca3b4cdbcb4a441a69964125326dL19-R20)

**Blade View Enhancements:**

* Refactored `resources/views/components/headline.blade.php` to support dynamic alignment, headline sizes (including new 2xl–4xl options), and keyword highlighting within headings. Also improved badge rendering logic. [[1]](diffhunk://#diff-6aaacf9838cda03ee10efe45f612181a1af91d9d291de1232c6061a9552ccdf8R30-R40) [[2]](diffhunk://#diff-6aaacf9838cda03ee10efe45f612181a1af91d9d291de1232c6061a9552ccdf8L49-R129)
* Updated section views (`cta-full-width.blade.php`, `info-stats.blade.php`) to use the new headline component, removing direct use of title/subheading fields and ensuring consistent layout. [[1]](diffhunk://#diff-d870fc976b91daa1256239beaa628a30242c7aa108ccd3c6debb5ef6959adb6bL23-R24) [[2]](diffhunk://#diff-be4a1dba213ea23fd86b50b6b07497ac47c162e9f3d478fcf566c75c98e9c9d1L13-R17)

**Badge and Button DTO Improvements:**

* Improved form and make logic for `BadgeComponent` and `ButtonComponent` DTOs, handling missing data more gracefully and updating field keys for consistency with new parent structures. [[1]](diffhunk://#diff-00e0e59cb95809e28ca6e9c93eb97a97be1f069846ea08e9e2430772f67c4402L15-R33) [[2]](diffhunk://#diff-6d8d041842a2469d2b87a4bdce4311438756a8fcefa2cb7face6618206da67d6R60-R71)

**Other UI/UX Adjustments:**

* Added collapsibility to metrics repeater in `InfoStatsComponent`.
* Cleaned up unused or redundant fields and code in several components, improving maintainability. [[1]](diffhunk://#diff-1ab388f925913e6760e9ebd3ea96538225b42827ad6f4d7b8122377be6257e73L22-L24) [[2]](diffhunk://#diff-8d59f5ab8ae056ccd4bc9b92e731afb4d0b4fd2265d79a066a232bf4e1aff13eL73-R69) [[3]](diffhunk://#diff-c7c51e83b03c94c1daa235fc30964c8449e4ca3b4cdbcb4a441a69964125326dL87-L92)

This refactor improves maintainability, consistency, and flexibility for headline rendering and related UI features across the codebase.