### PR TITLE
fix: navbar logo and filament storage disk

### DIFF
--- a/config/filament.php
+++ b/config/filament.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Filesystem Disk
+    |--------------------------------------------------------------------------
+    |
+    | Filament's file uploads (avatars, covers, etc.) must default to a
+    | publicly servable disk regardless of the app's general FILESYSTEM_DISK,
+    | which defaults to the private "local" disk since Laravel 11.
+    |
+    */
+
+    'default_filesystem_disk' => 'public',
+
+];

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -119,7 +119,10 @@
     class="h-full"
 >
     <nav class="relative mx-auto flex h-full items-center justify-between px-4 sm:px-12 lg:px-24">
-        <x-logo />
+        <x-logo-with-text
+            size="sm"
+            class="[&_.st0]:text-brand-primary [&_.st1]:text-text-high !w-[94px] lg:!w-[212px]"
+        />
 
         <div class="absolute left-1/2 hidden -translate-x-1/2 items-center gap-8 lg:flex">
             @foreach ($primaryLinks as $link)

--- a/tests/Feature/Filament/TestimonialResourceTest.php
+++ b/tests/Feature/Filament/TestimonialResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Testimonials\Pages\CreateTestimonial;
+use App\Models\Testimonial;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Livewire\livewire;
+
+it('stores the testimonial avatar on the public disk so it is web-accessible', function (): void {
+    Storage::fake('public');
+
+    $this->actingAs(User::factory()->create());
+
+    livewire(CreateTestimonial::class)
+        ->fillForm([
+            'name' => 'Jane Doe',
+            'role' => 'CEO',
+            'rating' => 5,
+            'comment' => 'Great service.',
+            'posted_at' => now(),
+            'avatar' => UploadedFile::fake()->image('avatar.jpg'),
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $media = Testimonial::query()->firstOrFail()->getFirstMedia('avatar');
+
+    expect($media->disk)->toBe('public');
+    Storage::disk('public')->assertExists($media->getPathRelativeToRoot());
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Filament uploads now use publicly accessible storage by default, improving access to uploaded testimonial avatars.
  - Updated the navigation bar with a branded logo featuring custom sizing and styling.

- **Bug Fixes**
  - Improved reliability of testimonial creation with avatar uploads, ensuring uploaded files are stored and available correctly.

- **Tests**
  - Added coverage for testimonial creation and avatar upload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->