### PR TITLE
feat: parcerias layout tweaks

### DIFF
--- a/resources/views/components/partner-form.blade.php
+++ b/resources/views/components/partner-form.blade.php
@@ -117,7 +117,7 @@
                 ></textarea>
             </div>
 
-            <x-fr-button type="submit"> {{ $submitLabel }} </x-fr-button>
+            <x-fr-button type="submit" class="md:self-end"> {{ $submitLabel }} </x-fr-button>
         </form>
     </div>
 </section>

--- a/resources/views/pages/parcerias.blade.php
+++ b/resources/views/pages/parcerias.blade.php
@@ -4,15 +4,12 @@
     splashLogoClass="text-brand-primary"
 >
     <section class="section-first">
-        <div
-            class="container flex flex-col items-center gap-8 pt-8 pb-10 md:pt-20 md:pr-60 md:pb-16 md:pl-60"
-            data-reveal-stagger="140"
-        >
+        <div class="container flex flex-col items-center gap-8 pt-8 pb-10 md:pt-20 md:pb-16" data-reveal-stagger="140">
             <x-fr-headline size="2xl" data-reveal="up">
                 <x-slot:title>
                     A transformação se constrói com <mark>boas alianças</mark>
                 </x-slot:title>
-                <x-slot:description>
+                <x-slot:description class="md:px-60">
                     Não trabalhamos com parcerias de vitrine. Buscamos quem tem propósito alinhado e algo real a
                     construir junto e estamos prontos para investir de verdade nessa construção.
                 </x-slot:description>
@@ -26,7 +23,7 @@
         <img
             src="{{ asset('images/parcerias_1x.webp') }}"
             alt="Aperto de mãos representando uma parceria"
-            class="aspect-[393/328] w-full object-cover md:hidden"
+            class="aspect-[393/328] max-h-82 w-full object-cover md:hidden"
         />
 
         <div class="container mt-8 flex flex-col gap-8 md:mt-0 md:flex-row md:items-start md:gap-16">
@@ -73,12 +70,12 @@
                 </div>
             </div>
 
-            <div class="relative hidden w-full md:block md:min-h-160 md:basis-2/5" data-reveal="scale">
+            <div class="relative hidden w-full md:block md:min-h-160 md:basis-2/5 md:self-center" data-reveal="scale">
                 <div class="absolute top-0 left-0 -z-1 rounded-lg bg-linear-to-b"></div>
                 <img
                     src="{{ asset('images/parcerias_1x.webp') }}"
                     alt="Aperto de mãos representando uma parceria"
-                    class="absolute inset-0 h-full w-full rounded-lg object-contain object-top"
+                    class="absolute inset-0 h-full w-full rounded-lg object-contain object-center"
                 />
             </div>
         </div>

--- a/tests/Feature/ParceriasPageTest.php
+++ b/tests/Feature/ParceriasPageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+it('exibe a página de parcerias', function (): void {
+    $this->get(route('parcerias'))
+        ->assertOk()
+        ->assertSee('Quem pode ser parceiro da')
+        ->assertSee('O que buscamos')
+        ->assertSee('Influenciadores e criadores de conteúdo.');
+});
+
+it('usa a mesma largura das demais seções no hero', function (): void {
+    $content = (string) $this->get(route('parcerias'))->assertOk()->getContent();
+
+    preg_match('/<div class="container[^"]*"[^>]*data-reveal-stagger/', $content, $matches);
+
+    expect($matches)->not->toBeEmpty();
+
+    expect($matches[0])->not->toMatch('/\bmd:p[rl]-60\b/');
+});
+
+it('mantém apenas a descrição do hero com a largura reduzida', function (): void {
+    $content = (string) $this->get(route('parcerias'))->assertOk()->getContent();
+
+    preg_match('/<p[^>]*fr-headline-description[^>]*>\s*Não trabalhamos com parcerias/u', $content, $matches);
+
+    expect($matches)->not->toBeEmpty();
+
+    expect($matches[0])->toContain('md:px-60');
+});
+
+it('limita a altura da imagem de topo no mobile', function (): void {
+    $content = (string) $this->get(route('parcerias'))->assertOk()->getContent();
+
+    preg_match('/<img[^>]*parcerias_1x\.webp[^>]*md:hidden[^>]*>/s', $content, $matches);
+
+    expect($matches)->not->toBeEmpty();
+
+    expect($matches[0])->toContain('max-h-82')->toContain('object-cover');
+});
+
+it('centraliza verticalmente a imagem ao lado de "quem pode ser parceiro"', function (): void {
+    $content = (string) $this->get(route('parcerias'))->assertOk()->getContent();
+
+    expect($content)->toContain('md:basis-2/5 md:self-center');
+
+    preg_match('/<img[^>]*parcerias_1x\.webp[^>]*object-contain[^>]*>/s', $content, $matches);
+
+    expect($matches)->not->toBeEmpty();
+
+    expect($matches[0])->toContain('object-center')->not->toContain('object-top');
+});
+
+it('encolhe o botão do formulário e o joga para a direita a partir do md', function (): void {
+    $content = (string) $this->get(route('parcerias'))->assertOk()->getContent();
+
+    preg_match('/<button[^>]*type="submit"[^>]*>/', $content, $matches);
+
+    expect($matches)->not->toBeEmpty();
+
+    expect($matches[0])->toContain('md:self-end')->not->toContain('fr-button-block');
+});


### PR DESCRIPTION
- Center the "quem pode ser parceiro" photo next to its text column.
- Shrink the form submit button and push it right from md up.
- Give the hero title the same width as the other sections, keeping the reduced width on the description alone.
- Cap the mobile top image height so it stops growing with the viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout on the partnerships page.
  * Centered and constrained the hero image for better mobile and desktop presentation.
  * Added desktop spacing around the partnership description.
  * Aligned the form’s submit button to the right on medium and larger screens.

* **Tests**
  * Added coverage for page rendering, content, image sizing, alignment, and responsive form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->