### PR TITLE
fix: registra config services.posthog para ativar o snippet do PostHog

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -37,4 +37,9 @@ return [
         ],
     ],
 
+    'posthog' => [
+        'api_key' => env('POSTHOG_API_KEY'),
+        'host' => env('POSTHOG_HOST', 'https://us.i.posthog.com'),
+    ],
+
 ];

--- a/tests/Feature/PostHogSnippetTest.php
+++ b/tests/Feature/PostHogSnippetTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+it('renders the PostHog snippet on landing pages when the api key is configured', function (): void {
+    config()->set('services.posthog.api_key', 'phc_test_key');
+    config()->set('services.posthog.host', 'https://us.i.posthog.com');
+
+    $response = $this->get('/');
+
+    $response->assertOk();
+
+    expect((string) $response->getContent())
+        ->toContain("posthog.init('phc_test_key'")
+        ->toContain("api_host: 'https://us.i.posthog.com'");
+});
+
+it('does not render the PostHog snippet when the api key is missing', function (): void {
+    config()->set('services.posthog.api_key');
+
+    $response = $this->get('/');
+
+    $response->assertOk();
+
+    expect((string) $response->getContent())->not->toContain('posthog.init');
+});

--- a/tests/Feature/PostHogSnippetTest.php
+++ b/tests/Feature/PostHogSnippetTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 it('renders the PostHog snippet on landing pages when the api key is configured', function (): void {
     config()->set('services.posthog.api_key', 'phc_test_key');
-    config()->set('services.posthog.host', 'https://us.i.posthog.com');
+    config()->set('services.posthog.host', 'https://eu.i.posthog.com');
 
     $response = $this->get('/');
 
@@ -12,6 +12,17 @@ it('renders the PostHog snippet on landing pages when the api key is configured'
 
     expect((string) $response->getContent())
         ->toContain("posthog.init('phc_test_key'")
+        ->toContain("api_host: 'https://eu.i.posthog.com'");
+});
+
+it('falls back to the default PostHog host when POSTHOG_HOST is not set', function (): void {
+    config()->set('services.posthog.api_key', 'phc_test_key');
+
+    $response = $this->get('/');
+
+    $response->assertOk();
+
+    expect((string) $response->getContent())
         ->toContain("api_host: 'https://us.i.posthog.com'");
 });
 


### PR DESCRIPTION
## Problema

O layout `landing.blade.php` renderiza o snippet do PostHog condicionado a `config('services.posthog.api_key')`, mas não existia a entrada `posthog` em `config/services.php`. Com isso, mesmo com `POSTHOG_API_KEY` e `POSTHOG_HOST` definidos no `.env` de produção, o valor era sempre `null` e o script nunca era injetado — nenhum evento capturado.

## Solução

- Registra o bloco `services.posthog` lendo `POSTHOG_API_KEY` e `POSTHOG_HOST` (default `https://us.i.posthog.com`).
- Adiciona `tests/Feature/PostHogSnippetTest.php` cobrindo os dois cenários: snippet renderizado com a chave configurada e ausente sem ela.

## Pós-deploy

Rodar `php artisan config:cache` em produção para o cache de config pegar os novos valores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostHog analytics configuration with support for environment-based credentials and a configurable host.
  * PostHog tracking now appears on landing pages when configured.

* **Bug Fixes**
  * Prevented the analytics snippet from rendering when no API key is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->